### PR TITLE
Bumping to 0.4.3 to mark protocol incompatibility.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('agentd', 'c', 'cpp',
-    version : '0.4.2-snapshot',
+    version : '0.4.3-snapshot',
     default_options : ['c_std=gnu11', 'cpp_std=c++14', 'buildtype=release'],
     meson_version : '>=0.53.0'
 )


### PR DESCRIPTION
From here on out, 0.4.3 is protocol incompatible with previous versions of client libraries.